### PR TITLE
[Fix] Readme examples mismatch

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ scrape_configs:
     params:
       format: ['prometheus']
     static_configs:
-      - targets: ['marge.0123e.ru']
+      - targets: ['localhost']
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ server {
     access_log  /var/log/nginx/localhost-access.log  main;
     error_log  /var/log/nginx/localhost-error.log;
 
-    location /metrics {
+    location /check_certificates/metrics {
         alias /opt/check_certificates/metrics;
         allow 127.0.0.1/32;
         deny  all;


### PR DESCRIPTION
# Description

Readme examples mismatch (/check_certificates/metrics vs /metrics)


# Checklist

- [ ] Your code works
- [ ] The changes are cool
- [ ] The version is bumped
